### PR TITLE
docs: fix dead link to Camunda Connector Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ mvn clean verify
 
 ### Test as local Job Worker
 
-Use the [Camunda Job Worker Connector Run-Time](https://github.com/camunda/connector-framework/tree/main/runtime-job-worker)
+Use the [Camunda Connector Runtime](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#building-connector-runtime-bundles)
 to run your function as a local Job Worker.
 
 ### :lock: Test as local Google Cloud Function


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Fixes the link in [`README.md`](https://github.com/camunda/connector-google-drive/blob/c4c6c5647e45a57727f085d07653a436f57333eb/README.md?plain=1#L150) to [Camunda Connector Runtime](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#building-connector-runtime-bundles). This is similar to:
- camunda/connector-sendgrid#139
- camunda/connector-slack#139
## Related issues

<!-- Which issues are closed by this PR or are related -->
No related issue.

